### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/src/deepr.js
+++ b/src/deepr.js
@@ -31,6 +31,8 @@ const mergeArray = (prev, next, clone) => {
 const mergeObject = (prev, next, clone) => {
   const state = clone ? Object.assign({}, prev) : prev;
   Object.keys(next).forEach(key => {
+    if (isPrototypePolluted(key))
+      return
     const val = next[key];
     const type = utils.getType(val);
     switch (type) {
@@ -91,9 +93,9 @@ const merge = (prev, next, clone = false) => {
   switch (type) {
     case ARRAY:
       return mergeArray(prev, next, clone);
-    case OBJECT:
-      return mergeObject(prev, next, clone);
-    default:
+      case OBJECT:
+        return mergeObject(prev, next, clone);
+        default:
       return mergePrimative(prev, next);
   }
 }
@@ -103,5 +105,7 @@ const validate = (change, policy) => {
   validateObject(change, policy, errors);
   return { valid: errors.length === 0, errors }
 };
+
+const isPrototypePolluted = (key) => ['__proto__', 'constructor', 'prototype'].includes(key)
 
 module.exports = { merge, validate };


### PR DESCRIPTION
https://huntr.dev/users/arjunshibu has fixed the Prototype Pollution vulnerability 🔨. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/deepr/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/deepr/1/README.md

### User Comments:

### :bar_chart: Metadata *

`deepr` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-deepr/

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```javascript
// poc.js
var deepr = require("deepr")
const payload = JSON.parse('{"__proto__":{"polluted":"Yes! Its Polluted"}}');
var obj = {}
console.log("Before : " + {}.polluted);
deepr.merge(obj, payload);
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i deepr # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/102845090-c6d78a00-4432-11eb-91fc-35866daff141.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
